### PR TITLE
`publish_event` backoff strategy improvement

### DIFF
--- a/app/services/activity_logger.py
+++ b/app/services/activity_logger.py
@@ -25,7 +25,11 @@ logger = logging.getLogger(__name__)
 
 # Publish events for other services or system components
 @stamina.retry(
-    on=(aiohttp.ClientError, asyncio.TimeoutError), attempts=5
+    on=(aiohttp.ClientError, asyncio.TimeoutError),
+    attempts=5,
+    wait_initial=1.0,
+    wait_max=10,
+    wait_jitter=3.0
 )
 async def publish_event(event: SystemEventBaseModel, topic_name: str):
     timeout_settings = aiohttp.ClientTimeout(total=10.0)

--- a/app/services/activity_logger.py
+++ b/app/services/activity_logger.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
     on=(aiohttp.ClientError, asyncio.TimeoutError),
     attempts=5,
     wait_initial=1.0,
-    wait_max=10,
+    wait_max=30,
     wait_jitter=3.0
 )
 async def publish_event(event: SystemEventBaseModel, topic_name: str):


### PR DESCRIPTION
To avoid:

![image](https://github.com/PADAS/gundi-integration-action-runner/assets/29244324/198927d9-9810-423d-babe-2f110210623f)

This improvement helps mitigate the error shown above, but it is not completely avoided.