### PR TITLE
GUNDI-3171: Improve retry settings on requests to the portal

### DIFF
--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -28,8 +28,9 @@ async def execute_action(integration_id: str, action_id: str, config_overrides: 
     """
     logger.info(f"Executing action '{action_id}' for integration '{integration_id}'...")
     try:  # Get the integration config from the portal
-        async for attempt in stamina.retry_context(on=httpx.HTTPError, wait_initial=datetime.timedelta(seconds=1), attempts=3):
+        async for attempt in stamina.retry_context(on=httpx.HTTPError, wait_initial=1.0, wait_jitter=5.0, wait_max=32.0):
             with attempt:
+                # ToDo: Store configs and update it on changes (event-driven architecture)
                 integration = await _portal.get_integration_details(integration_id=integration_id)
     except Exception as e:
         message = f"Error retrieving configuration for integration '{integration_id}': {e}"

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -5,7 +5,7 @@ import stamina
 from gundi_client_v2.client import GundiClient, GundiDataSenderClient
 
 
-@stamina.retry(on=httpx.HTTPError, attempts=3, wait_initial=datetime.timedelta(seconds=1), wait_max=datetime.timedelta(seconds=10))
+@stamina.retry(on=httpx.HTTPError, wait_initial=1.0, wait_jitter=5.0, wait_max=32.0)
 async def _get_gundi_api_key(integration_id):
     async with GundiClient() as gundi_client:
         return await gundi_client.get_integration_api_key(
@@ -22,7 +22,7 @@ async def _get_sensors_api_client(integration_id):
     return sensors_api_client
 
 
-@stamina.retry(on=httpx.HTTPError, attempts=3, wait_initial=datetime.timedelta(seconds=1), wait_max=datetime.timedelta(seconds=10))
+@stamina.retry(on=httpx.HTTPError, wait_initial=1.0, wait_jitter=5.0, wait_max=32.0)
 async def send_events_to_gundi(events: List[dict], **kwargs) -> dict:
     """
     Send Events to Gundi using the REST API v2
@@ -51,7 +51,7 @@ async def send_events_to_gundi(events: List[dict], **kwargs) -> dict:
     return await sensors_api_client.post_events(data=events)
 
 
-@stamina.retry(on=httpx.HTTPError, attempts=3, wait_initial=datetime.timedelta(seconds=1), wait_max=datetime.timedelta(seconds=10))
+@stamina.retry(on=httpx.HTTPError, wait_initial=1.0, wait_jitter=5.0, wait_max=32.0)
 async def send_observations_to_gundi(observations: List[dict], **kwargs) -> dict:
     """
     Send Observations to Gundi using the REST API v2


### PR DESCRIPTION
### What does this PR do?
- Modifies retry settings on portal API errors. This is intended to help reduce errors like the ones we saw in the skylight integration while retrieving configurations from the portal.

### Relevant link(s)
[GUNDI-3171](https://allenai.atlassian.net/browse/GUNDI-3171)

[GUNDI-3171]: https://allenai.atlassian.net/browse/GUNDI-3171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ