### PR TITLE
Fix Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.10-slim
 
+# This command is for webhooks support
+RUN apt-get update && apt-get install -y autoconf automake libtool make python3-dev
+
 WORKDIR /code
 
 COPY requirements.txt .


### PR DESCRIPTION
Since the template repo now supports webhooks, this addition is needed for all the forked repos (build action is failing because of this).