### PR TITLE
GUNDI-3819: Support custom action schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Template repo for integration in Gundi v2.
     - Webhook execution complete
     - Error occurred during webhook execution
 - Optionally, use  `log_action_activity()` or `log_webhook_activity()` to log custom messages which you can later see in the portal
+- Optionally, use  `@crontab_schedule()` or `register.py --schedule` to make an action to run on a custom schedule
 
 
 ## Action Examples: 
@@ -35,10 +36,12 @@ class PullObservationsConfiguration(PullActionConfiguration):
 # actions/handlers.py
 from app.services.activity_logger import activity_logger, log_activity
 from app.services.gundi import send_observations_to_gundi
+from app.services.utils import crontab_schedule
 from gundi_core.events import LogLevel
 from .configurations import PullObservationsConfiguration
 
 
+@crontab_schedule("0 */4 * * *")  # Run every 4 hours
 @activity_logger()
 async def action_pull_observations(integration, action_config: PullObservationsConfiguration):
     

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -31,7 +31,7 @@ from app.actions import (
     AuthActionConfiguration,
     ExecutableActionMixin,
 )
-from app.services.utils import GlobalUISchemaOptions, FieldWithUIOptions, UIOptions
+from app.services.utils import GlobalUISchemaOptions, FieldWithUIOptions, UIOptions, CrontabSchedule
 from app.webhooks import (
     GenericJsonTransformConfig,
     GenericJsonPayload,
@@ -869,6 +869,7 @@ class MockAuthenticateActionConfiguration(
 def mock_action_handlers(mocker):
     mock_action_handler = AsyncMock()
     mock_action_handler.return_value = {"observations_extracted": 10}
+    mock_action_handler.crontab_schedule = CrontabSchedule.parse_obj_from_crontab("*/10 * * * * -5")
     mock_action_handlers = {
         "pull_observations": (mock_action_handler, MockPullActionConfiguration)
     }

--- a/app/register.py
+++ b/app/register.py
@@ -2,13 +2,35 @@ import asyncio
 import click
 from app.services.action_runner import _portal
 from app.services.self_registration import register_integration_in_gundi
+from app.services.utils import CrontabSchedule
 
 
 @click.command()
 @click.option('--slug', default=None, help='Slug ID for the integration type')
 @click.option('--service-url', default=None, help='Service URL used to trigger actions or receive webhooks')
-def register_integration(slug, service_url):
-    asyncio.run(register_integration_in_gundi(gundi_client=_portal, type_slug=slug, service_url=service_url))
+@click.option(
+    '--schedule',
+    multiple=True,
+    help='Schedules in the format "action_id:crontab schedule" (e.g., "pull_events:0 */4 * * *")'
+)
+def register_integration(slug, service_url, schedule):
+    schedules = {}
+    for item in schedule:
+        try:
+            action_id, cron_schedule = item.split(":", 1)
+            schedules[action_id.strip()] = CrontabSchedule.parse_obj_from_crontab(cron_schedule.strip())
+        except ValueError:
+            raise click.BadParameter(
+                f"Invalid schedule format: {item}. Expected format is 'action_id:schedule'."
+            )
+    asyncio.run(
+        register_integration_in_gundi(
+            gundi_client=_portal,
+            type_slug=slug,
+            service_url=service_url,
+            action_schedules=schedules
+        )
+    )
 
 
 # Main

--- a/app/register.py
+++ b/app/register.py
@@ -1,5 +1,7 @@
 import asyncio
 import click
+import pydantic
+
 from app.services.action_runner import _portal
 from app.services.self_registration import register_integration_in_gundi
 from app.services.utils import CrontabSchedule
@@ -19,9 +21,9 @@ def register_integration(slug, service_url, schedule):
         try:
             action_id, cron_schedule = item.split(":", 1)
             schedules[action_id.strip()] = CrontabSchedule.parse_obj_from_crontab(cron_schedule.strip())
-        except ValueError:
+        except (pydantic.ValidationError, ValueError) as e:
             raise click.BadParameter(
-                f"Invalid schedule format: {item}. Expected format is 'action_id:schedule'."
+                f"Invalid schedule format: {item}.\n Expected format is 'action_id:MIN HOUR DOM MON DOW [TZ]'. e.g., 'pull_events:0 */4 * * * -5'. \n {e}"
             )
     asyncio.run(
         register_integration_in_gundi(

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -1,9 +1,10 @@
-import datetime
 import logging
+
 import httpx
 import pydantic
 import stamina
 from gundi_client_v2 import GundiClient
+
 from app.actions import action_handlers
 from app import settings
 from fastapi import status
@@ -137,3 +138,7 @@ async def execute_action(integration_id: str, action_id: str, config_overrides: 
         )
     else:
         return result
+
+
+
+

--- a/app/services/self_registration.py
+++ b/app/services/self_registration.py
@@ -19,7 +19,7 @@ from app.webhooks.core import get_webhook_handler, GenericJsonTransformConfig
 logger = logging.getLogger(__name__)
 
 
-async def register_integration_in_gundi(gundi_client, type_slug=None, service_url=None):
+async def register_integration_in_gundi(gundi_client, type_slug=None, service_url=None, action_schedules=None):
     # Prepare the integration name and value
     integration_type_slug = type_slug or INTEGRATION_TYPE_SLUG
     if not integration_type_slug:
@@ -43,7 +43,7 @@ async def register_integration_in_gundi(gundi_client, type_slug=None, service_ur
     # Prepare the actions and schemas
     actions = []
     for action_id, handler in action_handlers.items():
-        _, config_model = handler
+        func, config_model = handler
         action_name = action_id.replace("_", " ").title()
         action_schema = json.loads(config_model.schema_json())
         action_ui_schema = config_model.ui_schema()
@@ -59,19 +59,27 @@ async def register_integration_in_gundi(gundi_client, type_slug=None, service_ur
         if issubclass(config_model, ExecutableActionMixin):
             action_schema["is_executable"] = True
 
-        actions.append(
-            {
-                "type": action_type,
-                "name": action_name,
-                "value": action_id,
-                "description": f"{integration_type_name} {action_name} action",
-                "schema": action_schema,
-                "ui_schema": action_ui_schema,
-                "is_periodic_action": (
-                    True if issubclass(config_model, PullActionConfiguration) else False
-                ),
-            }
-        )
+        action = {
+            "type": action_type,
+            "name": action_name,
+            "value": action_id,
+            "description": f"{integration_type_name} {action_name} action",
+            "schema": action_schema,
+            "ui_schema": action_ui_schema,
+        }
+
+        if issubclass(config_model, PullActionConfiguration):
+            action["is_periodic_action"] = True
+            # Schedules can be specified by argument or using a decorator
+            if action_schedules and action_id in action_schedules:
+                action["crontab_schedule"] = action_schedules[action_id].dict()
+            elif crontab_schedule := getattr(func, "crontab_schedule"):
+                action["crontab_schedule"] = crontab_schedule.dict()
+        else:
+            action["is_periodic_action"] = False
+
+        actions.append(action)
+
     data["actions"] = actions
 
     try:  # Register webhook config if available

--- a/app/services/self_registration.py
+++ b/app/services/self_registration.py
@@ -73,7 +73,8 @@ async def register_integration_in_gundi(gundi_client, type_slug=None, service_ur
             # Schedules can be specified by argument or using a decorator
             if action_schedules and action_id in action_schedules:
                 action["crontab_schedule"] = action_schedules[action_id].dict()
-            elif crontab_schedule := getattr(func, "crontab_schedule"):
+            elif hasattr(func, "crontab_schedule"):
+                crontab_schedule = getattr(func, "crontab_schedule")
                 action["crontab_schedule"] = crontab_schedule.dict()
         else:
             action["is_periodic_action"] = False

--- a/app/services/tests/test_self_registration.py
+++ b/app/services/tests/test_self_registration.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 from app.main import app
 from app.services.self_registration import register_integration_in_gundi
+from app.services.utils import crontab_schedule, CrontabSchedule
 
 api_client = TestClient(app)
 
@@ -59,6 +60,14 @@ async def test_register_integration_with_slug_setting(
                         "ui:order": ["lookback_days", "force_fetch"],
                     },
                     "is_periodic_action": True,
+                    "crontab_schedule": {
+                        "day_of_month": "*",
+                        "day_of_week": "*",
+                        "hour": "*",
+                        "minute": "*/10",
+                        "month_of_year": "*",
+                        "tz_offset": -5
+                    },
                 }
             ],
             "webhook": {
@@ -146,6 +155,14 @@ async def test_register_integration_with_slug_arg(
                         "ui:order": ["lookback_days", "force_fetch"],
                     },
                     "is_periodic_action": True,
+                    "crontab_schedule": {
+                        "day_of_month": "*",
+                        "day_of_week": "*",
+                        "hour": "*",
+                        "minute": "*/10",
+                        "month_of_year": "*",
+                        "tz_offset": -5
+                    },
                 }
             ],
             "webhook": {
@@ -235,6 +252,14 @@ async def test_register_integration_with_service_url_arg(
                         "ui:order": ["lookback_days", "force_fetch"],
                     },
                     "is_periodic_action": True,
+                    "crontab_schedule": {
+                        "day_of_month": "*",
+                        "day_of_week": "*",
+                        "hour": "*",
+                        "minute": "*/10",
+                        "month_of_year": "*",
+                        "tz_offset": -5
+                    },
                 }
             ],
             "webhook": {
@@ -327,6 +352,14 @@ async def test_register_integration_with_service_url_setting(
                         "ui:order": ["lookback_days", "force_fetch"],
                     },
                     "is_periodic_action": True,
+                    "crontab_schedule": {
+                        "day_of_month": "*",
+                        "day_of_week": "*",
+                        "hour": "*",
+                        "minute": "*/10",
+                        "month_of_year": "*",
+                        "tz_offset": -5
+                    },
                 }
             ],
             "webhook": {
@@ -438,3 +471,26 @@ async def test_register_integration_with_executable_action(
             },
         }
     )
+
+
+@pytest.mark.asyncio
+async def test_crontab_schedule_decorator(
+        mocker, mock_publish_event, integration_v2, pull_observations_config
+):
+
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+
+    @crontab_schedule("5-55/10 * * * *")
+    async def action_pull_observations(integration, action_config):
+        return {"observations_extracted": 10}
+
+    assert hasattr(action_pull_observations, "crontab_schedule")
+    expected_schedule = CrontabSchedule(
+        minute='5-55/10',
+        hour='*',
+        day_of_week='*',
+        day_of_month='*',
+        month_of_year='*',
+        tz_offset=0
+    )
+    assert action_pull_observations.crontab_schedule == expected_schedule

--- a/app/services/utils.py
+++ b/app/services/utils.py
@@ -400,7 +400,15 @@ class CrontabSchedule(BaseModel):
     # build from crontab string
     @classmethod
     def parse_obj_from_crontab(cls, crontab: str):
-        minute, hour, day_of_month, month_of_year, day_of_week, tz_offset = crontab.split()
+        parts = crontab.split()
+        if len(parts) == 6:
+            minute, hour, day_of_month, month_of_year, day_of_week, tz_offset = parts
+        elif len(parts) == 5:
+            minute, hour, day_of_month, month_of_year, day_of_week = parts
+            tz_offset = 0
+        else:
+            raise ValueError("Invalid crontab format. Must have 5 or 6 fields.")
+
         return cls(
             minute=minute,
             hour=hour,

--- a/app/services/utils.py
+++ b/app/services/utils.py
@@ -1,9 +1,10 @@
 import struct
-from typing import Annotated
 import typing
+from functools import wraps
 from pydantic import create_model, BaseModel
 from pydantic.fields import Field, FieldInfo, Undefined, NoArgAnyCallable
-from typing import Any, Dict, Optional, Union, List
+from pydantic.class_validators import validator
+from typing import Any, Dict, Optional, Union, List, Annotated
 
 
 def find_config_for_action(configurations, action_id):
@@ -373,3 +374,54 @@ class UISchemaModelMixin:
             definitions.pop(field, None)
         json_schema_dict['definitions'] = definitions
         return json_schema_dict
+
+
+class CrontabSchedule(BaseModel):
+    minute: str = Field("0", regex=r"^(\*|([0-5]?\d)(,([0-5]?\d)|-([0-5]?\d)|/([1-5]?\d))*)$")
+    hour: str = Field("6", regex=r"^(\*|([01]?\d|2[0-3])(,([01]?\d|2[0-3])|-(\d+)|/([1-9]\d?))*)$")
+    day_of_week: str = Field("*", regex=r"^(\*|[0-6](,[0-6]|-[0-6]|/[0-6])*)$")
+    day_of_month: str = Field("*", regex=r"^(\*|([1-9]|[12]\d|3[01])(,([1-9]|[12]\d|3[01])|-(\d+)|/(\d+))*)$")
+    month_of_year: str = Field("*", regex=r"^(\*|([1-9]|1[0-2])(,([1-9]|1[0-2])|-(\d+)|/(\d+))*)$")
+    tz_offset: int = Field(0, description="Timezone offset from UTC, e.g., 0 for UTC, -5 for UTC-5, +2 for UTC+2")
+
+    @validator("tz_offset")
+    def validate_timezone(cls, value):
+        """Validate that timezone is an integer between -12 and +14."""
+        if not (-12 <= value <= 14):
+            raise ValueError("Timezone offset must be between -12 and +14.")
+        return value
+
+    @validator("minute", "hour", "day_of_week", "day_of_month", "month_of_year")
+    def validate_crontab_field(cls, value, field):
+        if not value:
+            raise ValueError(f"{field.name} cannot be empty.")
+        return value
+
+    # build from crontab string
+    @classmethod
+    def parse_obj_from_crontab(cls, crontab: str):
+        minute, hour, day_of_month, month_of_year, day_of_week, tz_offset = crontab.split()
+        return cls(
+            minute=minute,
+            hour=hour,
+            day_of_month=day_of_month,
+            month_of_year=month_of_year,
+            day_of_week=day_of_week,
+            tz_offset=int(tz_offset)
+        )
+
+
+# Defines when a periodic action runs. Can receive a CrontabSchedule object or a string as an argument
+def crontab_schedule(crontab: Union[CrontabSchedule, str]):
+    def decorator(func):
+        if isinstance(crontab, str):
+            schedule = CrontabSchedule.parse_obj_from_crontab(crontab)
+        else:
+            schedule = crontab
+        setattr(func, "crontab_schedule", schedule)
+
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            return await func(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/app/services/utils.py
+++ b/app/services/utils.py
@@ -377,12 +377,30 @@ class UISchemaModelMixin:
 
 
 class CrontabSchedule(BaseModel):
-    minute: str = Field("0", regex=r"^(\*|([0-5]?\d)(,([0-5]?\d)|-([0-5]?\d)|/([1-5]?\d))*)$")
-    hour: str = Field("6", regex=r"^(\*|([01]?\d|2[0-3])(,([01]?\d|2[0-3])|-(\d+)|/([1-9]\d?))*)$")
-    day_of_week: str = Field("*", regex=r"^(\*|[0-6](,[0-6]|-[0-6]|/[0-6])*)$")
-    day_of_month: str = Field("*", regex=r"^(\*|([1-9]|[12]\d|3[01])(,([1-9]|[12]\d|3[01])|-(\d+)|/(\d+))*)$")
-    month_of_year: str = Field("*", regex=r"^(\*|([1-9]|1[0-2])(,([1-9]|1[0-2])|-(\d+)|/(\d+))*)$")
-    tz_offset: int = Field(0, description="Timezone offset from UTC, e.g., 0 for UTC, -5 for UTC-5, +2 for UTC+2")
+    minute: str = Field(
+        "*",
+        regex=r"^(\*|([0-5]?\d)(,([0-5]?\d))*|([0-5]?\d-[0-5]?\d)(/\d+)?|\*(/\d+)?)$"
+    )
+    hour: str = Field(
+        "*",
+        regex=r"^(\*|([01]?\d|2[0-3])(,([01]?\d|2[0-3]))*|([01]?\d|2[0-3]-[01]?\d|2[0-3])(/\d+)?|\*(/\d+)?)$"
+    )
+    day_of_week: str = Field(
+        "*",
+        regex=r"^(\*|[0-6](,[0-6])*|([0-6]-[0-6])(/\d+)?|\*(/\d+)?)$"
+    )
+    day_of_month: str = Field(
+        "*",
+        regex=r"^(\*|([1-9]|[12]\d|3[01])(,([1-9]|[12]\d|3[01]))*|([1-9]|[12]\d|3[01]-[1-9]|[12]\d|3[01])(/\d+)?|\*(/\d+)?)$"
+    )
+    month_of_year: str = Field(
+        "*",
+        regex=r"^(\*|([1-9]|1[0-2])(,([1-9]|1[0-2]))*|([1-9]|1[0-2]-[1-9]|1[0-2])(/\d+)?|\*(/\d+)?)$"
+    )
+    tz_offset: int = Field(
+        0,
+        description="Timezone offset from UTC, e.g., 0 for UTC, -5 for UTC-5, +2 for UTC+2"
+    )
 
     @validator("tz_offset")
     def validate_timezone(cls, value):


### PR DESCRIPTION
### What does this PR do?
- Adds support for specifying a custom crontab schedule for periodic actions. This can be done either with a param passed to the register command or in the code with a decorator.
- Adds a minimal example in the README
- Test coverage

### Relevant link(s)
[GUNDI-3819](https://allenai.atlassian.net/browse/GUNDI-3819)

[GUNDI-3819]: https://allenai.atlassian.net/browse/GUNDI-3819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ