### PR TITLE
GUNDI-3952: Fix issue in configurations manager

### DIFF
--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1007,7 +1007,7 @@ def mock_api_key():
 
 
 @pytest.fixture
-def event_v2_cloud_event_payload():
+def event_v2_pubsub_payload():
     timestamp = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     return {
         "message": {
@@ -1022,7 +1022,7 @@ def event_v2_cloud_event_payload():
 
 
 @pytest.fixture
-def event_v2_cloud_event_payload_with_config_overrides():
+def event_v2_pubsub_payload_with_config_overrides():
     timestamp = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     return {
         "message": {

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -87,8 +87,9 @@ class IntegrationConfigurationManager:
         integration_summary = await self.get_integration(integration_id)
         configurations = []
         for action in integration_summary.type.actions:
-            config = await self.get_action_configuration(integration_id, action.id)
-            configurations.append(config)
+            config = await self.get_action_configuration(integration_id, action.value)
+            if config:
+                configurations.append(config)
         return Integration(
             id=integration_summary.id,
             name=integration_summary.name,


### PR DESCRIPTION
### What does this PR do?
- Fixes an issue in the configurations manager where internal calls to `get_action_configuration(...)`  from `get_integration_details(...)` where using the action uuid instead of the slug id.
- Test coverage for the bugfix

### Relevant link(s)
[GUNDI-3952](https://allenai.atlassian.net/browse/GUNDI-3952)




[GUNDI-3952]: https://allenai.atlassian.net/browse/GUNDI-3952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ