### PR TITLE
GUNDI-4619: Support metadata in push actions

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -116,6 +116,7 @@ async def push_data(
     return await execute_action(
         integration_id=destination_id,
         data=json_payload,
+        metadata=attributes
     )
 
 app.include_router(

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -74,7 +74,8 @@ async def _handle_error(
 
 
 async def execute_action(
-        integration_id: str, action_id: Optional[str] = None, config_overrides: dict = None, data: dict = None
+        integration_id: str, action_id: Optional[str] = None, config_overrides: dict = None,
+        data: dict = None, metadata: dict = None
 ):
     try:  # Get the integration details to pass it to the action handler
         integration = await config_manager.get_integration_details(integration_id)
@@ -143,6 +144,8 @@ async def execute_action(
         }
         if parsed_data:
             handler_kwargs["data"] = parsed_data
+        if metadata:
+            handler_kwargs["metadata"] = metadata
         result = await asyncio.wait_for(
             handler(**handler_kwargs),
             timeout=settings.MAX_ACTION_EXECUTION_TIME

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -81,6 +81,9 @@ async def test_execute_push_action_from_pubsub(
     data = call_kwargs.get("data")
     assert isinstance(data, ObservationTransformedER)
     assert data == ObservationTransformedER.parse_obj(payload_dict)
+    metadata = call_kwargs.get("metadata")
+    assert isinstance(metadata, dict)
+    assert metadata == attributes
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR updates the action execution logic for push-data actions to pass gundi attributes from PubSub messages to the action handlers, as metadata. This metadata includes things like the open telemetry tracing context (needed to generate new spans connected to a root trace), and other gundi attributes useful for troubleshooting or advanced use cases (e.g., the `gundi_id` which we usually save in the activity logs)  
