### PR TITLE
GUNDI-4722: Webhook support improvements

### DIFF
--- a/app/conftest.py
+++ b/app/conftest.py
@@ -139,6 +139,27 @@ def mock_redis_with_action_config(mocker, pull_observations_config_as_json):
 
 
 @pytest.fixture
+def mock_redis_with_webhook_config(mocker, integration_v2_with_webhook):
+    redis = MagicMock()
+    redis_client = mocker.MagicMock()
+    redis_client.set.return_value = async_return(MagicMock())
+    # Return webhook config JSON when asked for webhook key
+    webhook_config_json = integration_v2_with_webhook.webhook_configuration.json()
+    redis_client.get.return_value = async_return(webhook_config_json)
+    redis_client.delete.return_value = async_return(MagicMock())
+    redis_client.setex.return_value = async_return(None)
+    redis_client.incr.return_value = redis_client
+    redis_client.decr.return_value = async_return(None)
+    redis_client.expire.return_value = redis_client
+    redis_client.execute.return_value = async_return((1, True))
+    redis_client.__aenter__.return_value = redis_client
+    redis_client.__aexit__.return_value = None
+    redis_client.pipeline.return_value = redis_client
+    redis.Redis.return_value = redis_client
+    return redis
+
+
+@pytest.fixture
 def pull_observations_config_as_json():
     return json.dumps(
         {

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -811,6 +811,30 @@ def mock_gundi_client_v2_class(mocker, mock_gundi_client_v2):
 
 
 @pytest.fixture
+def mock_gundi_client_v2_class_for_webhooks(mocker, integration_v2_with_webhook):
+    """Mock GundiClient class for webhook tests that need cache miss simulation"""
+    mock_gundi_client_v2_class = mocker.MagicMock()
+    mock_gundi_instance = mocker.AsyncMock()
+    mock_gundi_instance.get_integration_details = mocker.AsyncMock(return_value=integration_v2_with_webhook)
+    mock_gundi_client_v2_class.return_value.__aenter__.return_value = mock_gundi_instance
+    mock_gundi_client_v2_class.return_value.__aexit__.return_value = None
+    return mock_gundi_client_v2_class
+
+
+@pytest.fixture
+def mock_gundi_client_v2_class_with_error(mocker):
+    """Mock GundiClient class that raises an exception for error testing"""
+    mock_gundi_client_v2_class = mocker.MagicMock()
+    mock_gundi_instance = mocker.AsyncMock()
+    mock_gundi_instance.get_integration_details = mocker.AsyncMock(
+        side_effect=Exception("Gundi API unavailable")
+    )
+    mock_gundi_client_v2_class.return_value.__aenter__.return_value = mock_gundi_instance
+    mock_gundi_client_v2_class.return_value.__aexit__.return_value = None
+    return mock_gundi_client_v2_class
+
+
+@pytest.fixture
 def mock_gundi_sensors_client_class(
     mocker,
     events_created_response,

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -5,7 +5,7 @@ import stamina
 from gundi_client_v2.client import GundiClient, GundiDataSenderClient
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=1.0, wait_jitter=5.0, wait_max=32.0)
+@stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
 async def _get_gundi_api_key(integration_id):
     async with GundiClient() as gundi_client:
         return await gundi_client.get_integration_api_key(
@@ -22,7 +22,7 @@ async def _get_sensors_api_client(integration_id):
     return sensors_api_client
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=1.0, wait_jitter=5.0, wait_max=32.0)
+@stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
 async def send_events_to_gundi(events: List[dict], **kwargs) -> dict:
     """
     Send Events to Gundi using the REST API v2
@@ -51,7 +51,7 @@ async def send_events_to_gundi(events: List[dict], **kwargs) -> dict:
     return await sensors_api_client.post_events(data=events)
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=1.0, wait_jitter=5.0, wait_max=32.0)
+@stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
 async def send_event_attachments_to_gundi(event_id: str, attachments: List[tuple], **kwargs) -> dict:
     """
     Send Event Attachments to Gundi using the REST API v2
@@ -69,7 +69,7 @@ async def send_event_attachments_to_gundi(event_id: str, attachments: List[tuple
     return await sensors_api_client.post_event_attachments(event_id=event_id, attachments=attachments)
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=1.0, wait_jitter=5.0, wait_max=32.0)
+@stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
 async def send_observations_to_gundi(observations: List[dict], **kwargs) -> dict:
     """
     Send Observations to Gundi using the REST API v2
@@ -99,7 +99,7 @@ async def send_observations_to_gundi(observations: List[dict], **kwargs) -> dict
     return await sensors_api_client.post_observations(data=observations)
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=1.0, wait_jitter=5.0, wait_max=32.0)
+@stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
 async def send_messages_to_gundi(messages: List[dict], **kwargs) -> dict:
     """
     Send Messages to Gundi using the REST API v2

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -50,7 +50,8 @@ async def test_set_integration(mocker, mock_redis_empty, mock_gundi_client_v2_cl
 
     mock_redis_empty.Redis.return_value.set.assert_called_once_with(
         f"integration.{integration_v2.id}",
-        integration_v2.json()
+        integration_v2.json(),
+        None  # Never expire
     )
 
 

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gundi_core.schemas.v2 import IntegrationSummary, IntegrationActionConfiguration, Integration
+from gundi_core.schemas.v2 import IntegrationSummary, IntegrationActionConfiguration, Integration, WebhookConfiguration
 from app.services.config_manager import IntegrationConfigurationManager
 
 
@@ -111,4 +111,213 @@ async def test_get_integration_details_with_empty_redis_db(
     for config in integration_v2.configurations:
         action_id = config.action.value
         mock_redis_empty.Redis.return_value.get.assert_any_call(f"integrationconfig.{integration_id}.{action_id}")
+
+
+# TTL Feature Tests
+
+@pytest.mark.asyncio
+async def test_get_integration_with_ttl(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+    ttl = 3600
+
+    integration = await config_manager.get_integration(integration_id, ttl=ttl)
+
+    assert integration
+    assert isinstance(integration, IntegrationSummary)
+    assert integration.id == integration_v2.id
+    # Verify that set was called with TTL for integration
+    mock_redis_empty.Redis.return_value.set.assert_any_call(
+        f"integration.{integration_id}",
+        integration.json(),
+        ttl
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_action_configuration_with_ttl(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+    action_v2 = integration_v2.configurations[0].action
+    action_id = action_v2.value
+    ttl = 1800
+
+    action_config = await config_manager.get_action_configuration(integration_id, action_id, ttl=ttl)
+
+    assert action_config
+    assert isinstance(action_config, IntegrationActionConfiguration)
+    # Verify that set was called with TTL for action config
+    mock_redis_empty.Redis.return_value.set.assert_any_call(
+        f"integrationconfig.{integration_id}.{action_id}",
+        action_config.json(),
+        ttl
+    )
+    # Verify that integration was also saved with TTL
+    mock_redis_empty.Redis.return_value.set.assert_any_call(
+        f"integration.{integration_id}",
+        mocker.ANY,  # The integration summary JSON
+        ttl
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_action_configuration_with_ttl(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+    action_v2 = integration_v2.configurations[0]
+    action_id = action_v2.action.value
+    ttl = 7200
+
+    await config_manager.set_action_configuration(integration_id, action_id, action_v2, ttl=ttl)
+
+    mock_redis_empty.Redis.return_value.set.assert_called_once_with(
+        f"integrationconfig.{integration_id}.{action_id}",
+        action_v2.json(),
+        ttl
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_integration_with_ttl(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    ttl = 900
+
+    await config_manager.set_integration(integration_v2, ttl=ttl)
+
+    mock_redis_empty.Redis.return_value.set.assert_called_once_with(
+        f"integration.{integration_v2.id}",
+        integration_v2.json(),
+        ttl
+    )
+
+
+# Webhook Configuration Tests
+
+@pytest.mark.asyncio
+async def test_get_webhook_configuration_from_redis(
+        mocker, mock_redis_with_webhook_config, mock_gundi_client_v2_class, integration_v2_with_webhook,
+):
+    mocker.patch("app.services.config_manager.redis", mock_redis_with_webhook_config)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2_with_webhook.id)
+
+    webhook_config = await config_manager.get_webhook_configuration(integration_id)
+
+    assert webhook_config
+    assert isinstance(webhook_config, WebhookConfiguration)
+    mock_redis_with_webhook_config.Redis.return_value.get.assert_called_once_with(
+        f"integrationconfig.{integration_id}.webhook"
+    )
+    assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
+
+
+@pytest.mark.asyncio
+async def test_get_webhook_configuration_from_gundi(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2_with_webhook,
+):
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    # Override the get_integration_details method to return webhook integration
+    mock_gundi_client_v2_class.return_value.get_integration_details = mocker.AsyncMock(return_value=integration_v2_with_webhook)
+    
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2_with_webhook.id)
+
+    webhook_config = await config_manager.get_webhook_configuration(integration_id)
+
+    assert webhook_config
+    assert isinstance(webhook_config, WebhookConfiguration)
+    mock_redis_empty.Redis.return_value.get.assert_called_once_with(
+        f"integrationconfig.{integration_id}.webhook"
+    )
+    mock_gundi_client_v2_class.return_value.get_integration_details.assert_called_once_with(integration_id)
+
+
+@pytest.mark.asyncio
+async def test_get_webhook_configuration_with_ttl(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2_with_webhook,
+):
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    # Override the get_integration_details method to return webhook integration
+    mock_gundi_client_v2_class.return_value.get_integration_details = mocker.AsyncMock(return_value=integration_v2_with_webhook)
+    
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2_with_webhook.id)
+    ttl = 2400
+
+    webhook_config = await config_manager.get_webhook_configuration(integration_id, ttl=ttl)
+
+    assert webhook_config
+    assert isinstance(webhook_config, WebhookConfiguration)
+    # Verify that set was called with TTL for webhook config
+    mock_redis_empty.Redis.return_value.set.assert_any_call(
+        f"integrationconfig.{integration_id}.webhook",
+        webhook_config.json(),
+        ttl
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_integration_details_with_webhook_configuration(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2_with_webhook,
+):
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    # Override the get_integration_details method to return webhook integration
+    mock_gundi_client_v2_class.return_value.get_integration_details = mocker.AsyncMock(return_value=integration_v2_with_webhook)
+    
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2_with_webhook.id)
+
+    integration = await config_manager.get_integration_details(integration_id)
+
+    assert integration
+    assert isinstance(integration, Integration)
+    assert integration.webhook_configuration is not None
+    assert isinstance(integration.webhook_configuration, WebhookConfiguration)
+    # Verify webhook config was fetched
+    mock_redis_empty.Redis.return_value.get.assert_any_call(
+        f"integrationconfig.{integration_id}.webhook"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_integration_details_with_ttl(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2_with_webhook,
+):
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    # Override the get_integration_details method to return webhook integration
+    mock_gundi_client_v2_class.return_value.get_integration_details = mocker.AsyncMock(return_value=integration_v2_with_webhook)
+    
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2_with_webhook.id)
+    ttl = 3000
+
+    integration = await config_manager.get_integration_details(integration_id, ttl=ttl)
+
+    assert integration
+    assert isinstance(integration, Integration)
+    # Verify that all set operations were called with TTL
+    set_calls = mock_redis_empty.Redis.return_value.set.call_args_list
+    for call in set_calls:
+        assert call[0][2] == ttl  # TTL is the third argument
 

--- a/app/services/tests/test_webhooks.py
+++ b/app/services/tests/test_webhooks.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from app.conftest import MockWebhookPayloadModel, MockWebhookConfigModel
 from app.main import app
 from app.webhooks import GenericJsonTransformConfig
+from app.services.config_manager import IntegrationConfigurationManager
 
 api_client = TestClient(app)
 
@@ -62,5 +63,335 @@ async def test_process_webhook_request_with_dynamic_schema(
         integration=integration_v2_with_webhook_generic,
         webhook_config=expected_config
     )
+
+
+# TTL Configuration Tests
+
+@pytest.mark.asyncio
+async def test_get_integration_calls_config_manager_with_ttl(
+        mocker, integration_v2_with_webhook
+):
+    """Test that get_integration calls config_manager.get_integration_details with ttl=60"""
+    mock_config_manager = mocker.patch("app.services.webhooks.config_manager")
+    mock_config_manager.get_integration_details = AsyncMock(return_value=integration_v2_with_webhook)
+    
+    from app.services.webhooks import get_integration
+    from fastapi import Request
+    
+    # Create a mock request with integration ID in headers
+    headers = {"x-gundi-integration-id": str(integration_v2_with_webhook.id)}
+    request = Request({"type": "http", "method": "POST", "url": "http://test/webhooks"})
+    request._headers = headers
+    request._query_params = {}
+    
+    integration = await get_integration(request)
+    
+    assert integration == integration_v2_with_webhook
+    mock_config_manager.get_integration_details.assert_called_once_with(
+        str(integration_v2_with_webhook.id), 
+        ttl=60
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_integration_with_integration_id_header(
+        mocker, integration_v2_with_webhook
+):
+    """Test that get_integration works with x-gundi-integration-id header"""
+    mock_config_manager = mocker.patch("app.services.webhooks.config_manager")
+    mock_config_manager.get_integration_details = AsyncMock(return_value=integration_v2_with_webhook)
+    
+    from app.services.webhooks import get_integration
+    from fastapi import Request
+    
+    # Create a mock request with x-gundi-integration-id header
+    headers = {"x-gundi-integration-id": str(integration_v2_with_webhook.id)}
+    request = Request({"type": "http", "method": "POST", "url": "http://test/webhooks"})
+    request._headers = headers
+    request._query_params = {}
+    
+    integration = await get_integration(request)
+    
+    assert integration == integration_v2_with_webhook
+    mock_config_manager.get_integration_details.assert_called_once_with(
+        str(integration_v2_with_webhook.id), 
+        ttl=60
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_integration_with_query_param(
+        mocker, integration_v2_with_webhook
+):
+    """Test that get_integration works with integration_id query parameter"""
+    mock_config_manager = mocker.patch("app.services.webhooks.config_manager")
+    mock_config_manager.get_integration_details = AsyncMock(return_value=integration_v2_with_webhook)
+    
+    from app.services.webhooks import get_integration
+    from fastapi import Request
+    
+    # Create a mock request with integration_id query param
+    request = Request({"type": "http", "method": "POST", "url": "http://test/webhooks"})
+    request._headers = {}
+    request._query_params = {"integration_id": str(integration_v2_with_webhook.id)}
+    
+    integration = await get_integration(request)
+    
+    assert integration == integration_v2_with_webhook
+    mock_config_manager.get_integration_details.assert_called_once_with(
+        str(integration_v2_with_webhook.id), 
+        ttl=60
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_integration_handles_config_manager_exception(
+        mocker, mock_publish_event
+):
+    """Test that get_integration handles config_manager exceptions gracefully"""
+    mock_config_manager = mocker.patch("app.services.webhooks.config_manager")
+    mock_config_manager.get_integration_details = AsyncMock(side_effect=Exception("Config manager error"))
+    
+    # Mock the publish_event function
+    mocker.patch("app.services.webhooks.publish_event", mock_publish_event)
+    
+    from app.services.webhooks import get_integration
+    from fastapi import Request
+    
+    # Create a mock request with integration ID
+    request = Request({"type": "http", "method": "POST", "url": "http://test/webhooks"})
+    request._headers = {"x-gundi-integration-id": "test-integration-id"}
+    request._query_params = {}
+    
+    integration = await get_integration(request)
+    
+    assert integration is None
+    mock_publish_event.assert_called_once()
+    # Verify the event contains the expected error information
+    call_args = mock_publish_event.call_args
+    assert "IntegrationWebhookFailed" in str(call_args)
+
+
+@pytest.mark.asyncio
+async def test_process_webhook_calls_config_manager_with_ttl(
+        mocker, integration_v2_with_webhook, mock_publish_event,
+        mock_get_webhook_handler_for_fixed_json_payload, mock_webhook_handler,
+        mock_webhook_request_payload_for_fixed_schema
+):
+    """Test that process_webhook calls config_manager.get_integration_details with ttl=60"""
+    mocker.patch("app.services.webhooks.get_webhook_handler", mock_get_webhook_handler_for_fixed_json_payload)
+    mock_config_manager = mocker.patch("app.services.webhooks.config_manager")
+    mock_config_manager.get_integration_details = AsyncMock(return_value=integration_v2_with_webhook)
+
+    # Use headers with the correct integration ID
+    headers = {"x-gundi-integration-id": str(integration_v2_with_webhook.id)}
+
+    response = api_client.post(
+        "/webhooks",
+        headers=headers,
+        json=mock_webhook_request_payload_for_fixed_schema,
+    )
+
+    assert response.status_code == 200
+    mock_config_manager.get_integration_details.assert_called_once_with(
+        str(integration_v2_with_webhook.id),
+        ttl=60
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_webhook_handles_no_integration_gracefully(
+        mocker, mock_publish_event, mock_webhook_request_payload_for_fixed_schema
+):
+    """Test that process_webhook handles the case when get_integration returns None gracefully"""
+    # Mock get_integration to return None
+    mocker.patch("app.services.webhooks.get_integration", return_value=None)
+    
+    # Mock the logger to capture warning messages
+    mock_logger = mocker.patch("app.services.webhooks.logger")
+    
+    from app.services.webhooks import process_webhook
+    from fastapi import Request
+    
+    # Create a mock request
+    request = Request({"type": "http", "method": "POST", "url": "http://test/webhooks"})
+    request._headers = {}
+    request._query_params = {}
+    request._json = lambda: mock_webhook_request_payload_for_fixed_schema
+    
+    result = await process_webhook(request)
+    
+    # Verify that the function returns an empty dictionary
+    assert result == {}
+    
+    # Verify that a warning was logged
+    mock_logger.warning.assert_called_once()
+    warning_call = mock_logger.warning.call_args[0][0]
+    assert "No integration found for webhook request" in warning_call
+    assert "headers:" in warning_call
+    assert "query_params:" in warning_call
+
+
+@pytest.mark.asyncio
+async def test_process_webhook_no_integration_via_api(
+        mocker, mock_publish_event, mock_webhook_request_payload_for_fixed_schema
+):
+    """Test that process_webhook handles no integration case via API endpoint"""
+    # Mock get_integration to return None
+    mocker.patch("app.services.webhooks.get_integration", return_value=None)
+    
+    # Mock the logger to capture warning messages
+    mock_logger = mocker.patch("app.services.webhooks.logger")
+    
+    # Make a request without any integration identification headers/params
+    response = api_client.post(
+        "/webhooks",
+        headers={},  # No integration identification
+        json=mock_webhook_request_payload_for_fixed_schema,
+    )
+    
+    # Verify that the API returns 200 (webhook processing doesn't fail)
+    assert response.status_code == 200
+    
+    # Verify that a warning was logged
+    mock_logger.warning.assert_called_once()
+    warning_call = mock_logger.warning.call_args[0][0]
+    assert "No integration found for webhook request" in warning_call
+
+
+# TTL Expiration and Gundi API Reload Tests
+
+@pytest.mark.asyncio
+async def test_process_webhook_reloads_from_gundi_on_cache_miss(
+        mocker, integration_v2_with_webhook, mock_publish_event,
+        mock_get_webhook_handler_for_fixed_json_payload, mock_webhook_handler,
+        mock_webhook_request_payload_for_fixed_schema, mock_redis_empty, mock_gundi_client_v2_class_for_webhooks
+):
+    """Test that process_webhook reloads integration from Gundi API when cache is empty (TTL expired)"""
+    # Patch Redis and GundiClient at the module level to simulate cache miss
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class_for_webhooks)
+    
+    # Create a new config manager instance with the patched dependencies
+    from app.services.config_manager import IntegrationConfigurationManager
+    config_manager = IntegrationConfigurationManager()
+    
+    # Patch the config_manager instance in the webhooks module
+    mocker.patch("app.services.webhooks.config_manager", config_manager)
+    
+    # Mock webhook handler
+    mocker.patch("app.services.webhooks.get_webhook_handler", mock_get_webhook_handler_for_fixed_json_payload)
+    
+    # Make webhook request
+    headers = {"x-gundi-integration-id": str(integration_v2_with_webhook.id)}
+    response = api_client.post(
+        "/webhooks",
+        headers=headers,
+        json=mock_webhook_request_payload_for_fixed_schema,
+    )
+    
+    # Verify successful response
+    assert response.status_code == 200
+    
+    # Verify that Redis was checked for cached data (cache miss)
+    mock_redis_empty.Redis.return_value.get.assert_called()
+    
+    # Verify that GundiClient was called to reload the integration
+    mock_gundi_instance = mock_gundi_client_v2_class_for_webhooks.return_value.__aenter__.return_value
+    mock_gundi_instance.get_integration_details.assert_called_with(str(integration_v2_with_webhook.id))
+    
+    # Verify that data was saved back to cache with TTL
+    mock_redis_empty.Redis.return_value.set.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_get_integration_reloads_from_gundi_on_cache_miss(
+        mocker, integration_v2_with_webhook, mock_redis_empty, mock_gundi_client_v2_class_for_webhooks
+):
+    """Test that get_integration reloads from Gundi API when cache is empty (TTL expired)"""
+    # Patch Redis and GundiClient at the module level to simulate cache miss
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class_for_webhooks)
+    
+    # Create a new config manager instance with the patched dependencies
+    from app.services.config_manager import IntegrationConfigurationManager
+    config_manager = IntegrationConfigurationManager()
+    
+    # Patch the config_manager instance in the webhooks module
+    mocker.patch("app.services.webhooks.config_manager", config_manager)
+    
+    from app.services.webhooks import get_integration
+    from fastapi import Request
+    
+    # Create a mock request with integration ID
+    headers = {"x-gundi-integration-id": str(integration_v2_with_webhook.id)}
+    request = Request({"type": "http", "method": "POST", "url": "http://test/webhooks"})
+    request._headers = headers
+    request._query_params = {}
+    
+    integration = await get_integration(request)
+    
+    # Verify that integration was retrieved
+    assert integration is not None
+    assert integration.id == integration_v2_with_webhook.id
+    assert integration.name == integration_v2_with_webhook.name
+    
+    # Verify that Redis was checked for cached data (cache miss)
+    mock_redis_empty.Redis.return_value.get.assert_called()
+    
+    # Verify that GundiClient was called to reload the integration
+    mock_gundi_instance = mock_gundi_client_v2_class_for_webhooks.return_value.__aenter__.return_value
+    mock_gundi_instance.get_integration_details.assert_called_with(str(integration_v2_with_webhook.id))
+    
+    # Verify that data was saved back to cache with TTL
+    mock_redis_empty.Redis.return_value.set.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_process_webhook_handles_gundi_api_failure_gracefully(
+        mocker, mock_publish_event, mock_webhook_request_payload_for_fixed_schema,
+        mock_redis_empty, mock_gundi_client_v2_class_with_error
+):
+    """Test that process_webhook handles Gundi API failures gracefully when reloading from cache miss"""
+    # Patch Redis and GundiClient at the module level to simulate cache miss and API failure
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class_with_error)
+    
+    # Create a new config manager instance with the patched dependencies
+    from app.services.config_manager import IntegrationConfigurationManager
+    config_manager = IntegrationConfigurationManager()
+    
+    # Patch the config_manager instance in the webhooks module
+    mocker.patch("app.services.webhooks.config_manager", config_manager)
+    
+    # Mock publish_event to capture the error event
+    mocker.patch("app.services.webhooks.publish_event", mock_publish_event)
+    
+    from app.services.webhooks import get_integration
+    from fastapi import Request
+    
+    # Create a mock request with integration ID
+    headers = {"x-gundi-integration-id": "test-integration-id"}
+    request = Request({"type": "http", "method": "POST", "url": "http://test/webhooks"})
+    request._headers = headers
+    request._query_params = {}
+    
+    integration = await get_integration(request)
+    
+    # Verify that integration is None due to the error
+    assert integration is None
+    
+    # Verify that Redis was checked for cached data (cache miss)
+    mock_redis_empty.Redis.return_value.get.assert_called()
+    
+    # Verify that GundiClient was called but failed
+    mock_gundi_instance = mock_gundi_client_v2_class_with_error.return_value.__aenter__.return_value
+    mock_gundi_instance.get_integration_details.assert_called_once_with("test-integration-id")
+    
+    # Verify that an error event was published
+    mock_publish_event.assert_called_once()
+    call_args = mock_publish_event.call_args
+    assert "IntegrationWebhookFailed" in str(call_args)
+    assert "Gundi API unavailable" in str(call_args)
 
 

--- a/app/services/tests/test_webhooks.py
+++ b/app/services/tests/test_webhooks.py
@@ -3,6 +3,7 @@ import json
 from unittest.mock import ANY
 
 import pytest
+from unittest.mock import AsyncMock
 from fastapi.testclient import TestClient
 
 from app.conftest import MockWebhookPayloadModel, MockWebhookConfigModel
@@ -14,12 +15,12 @@ api_client = TestClient(app)
 
 @pytest.mark.asyncio
 async def test_process_webhook_request_with_fixed_schema(
-        mocker, integration_v2_with_webhook, mock_gundi_client_v2_for_webhooks, mock_publish_event,
+        mocker, integration_v2_with_webhook, mock_publish_event,
         mock_get_webhook_handler_for_fixed_json_payload, mock_webhook_handler,
         mock_webhook_request_headers_onyesha, mock_webhook_request_payload_for_fixed_schema
 ):
     mocker.patch("app.services.webhooks.get_webhook_handler", mock_get_webhook_handler_for_fixed_json_payload)
-    mocker.patch("app.services.webhooks._portal", mock_gundi_client_v2_for_webhooks)
+    mocker.patch("app.services.config_manager.IntegrationConfigurationManager.get_integration_details", AsyncMock(return_value=integration_v2_with_webhook))
 
     response = api_client.post(
         "/webhooks",
@@ -28,7 +29,6 @@ async def test_process_webhook_request_with_fixed_schema(
     )
 
     assert response.status_code == 200
-    assert mock_gundi_client_v2_for_webhooks.get_integration_details.called
     assert mock_get_webhook_handler_for_fixed_json_payload.called
     expected_payload = MockWebhookPayloadModel.parse_obj(mock_webhook_request_payload_for_fixed_schema)
     expected_config = MockWebhookConfigModel.parse_obj(integration_v2_with_webhook.webhook_configuration.data)
@@ -41,12 +41,12 @@ async def test_process_webhook_request_with_fixed_schema(
 
 @pytest.mark.asyncio
 async def test_process_webhook_request_with_dynamic_schema(
-        mocker, integration_v2_with_webhook_generic, mock_gundi_client_v2_for_webhooks_generic, mock_publish_event,
+        mocker, integration_v2_with_webhook_generic, mock_publish_event,
         mock_get_webhook_handler_for_generic_json_payload, mock_webhook_handler,
         mock_webhook_request_headers_onyesha, mock_webhook_request_payload_for_dynamic_schema
 ):
     mocker.patch("app.services.webhooks.get_webhook_handler", mock_get_webhook_handler_for_generic_json_payload)
-    mocker.patch("app.services.webhooks._portal", mock_gundi_client_v2_for_webhooks_generic)
+    mocker.patch("app.services.config_manager.IntegrationConfigurationManager.get_integration_details", AsyncMock(return_value=integration_v2_with_webhook_generic))
 
     response = api_client.post(
         "/webhooks",
@@ -55,7 +55,6 @@ async def test_process_webhook_request_with_dynamic_schema(
     )
 
     assert response.status_code == 200
-    assert mock_gundi_client_v2_for_webhooks_generic.get_integration_details.called
     assert mock_get_webhook_handler_for_generic_json_payload.called
     expected_config = GenericJsonTransformConfig.parse_obj(integration_v2_with_webhook_generic.webhook_configuration.data)
     mock_webhook_handler.assert_called_once_with(

--- a/app/services/tests/test_webhooks.py
+++ b/app/services/tests/test_webhooks.py
@@ -76,13 +76,11 @@ async def test_get_integration_calls_config_manager_with_ttl(
     mock_config_manager.get_integration_details = AsyncMock(return_value=integration_v2_with_webhook)
     
     from app.services.webhooks import get_integration
-    from fastapi import Request
-    
     # Create a mock request with integration ID in headers
     headers = {"x-gundi-integration-id": str(integration_v2_with_webhook.id)}
-    request = Request({"type": "http", "method": "POST", "url": "http://test/webhooks"})
-    request._headers = headers
-    request._query_params = {}
+    request = mocker.Mock()
+    request.headers = headers
+    request.query_params = {}
     
     integration = await get_integration(request)
     

--- a/app/services/tests/test_webhooks.py
+++ b/app/services/tests/test_webhooks.py
@@ -217,7 +217,7 @@ async def test_process_webhook_handles_no_integration_gracefully(
     request = Request({"type": "http", "method": "POST", "url": "http://test/webhooks"})
     request._headers = {}
     request._query_params = {}
-    request._json = lambda: mock_webhook_request_payload_for_fixed_schema
+    mocker.patch.object(request, "json", AsyncMock(return_value=mock_webhook_request_payload_for_fixed_schema))
     
     result = await process_webhook(request)
     

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -35,8 +35,8 @@ async def get_integration(request):
             await publish_event(
                 event=IntegrationWebhookFailed(
                     payload=WebhookExecutionFailed(
-                        integration_id=str(integration.id),
-                        webhook_id=str(integration.type.webhook.value),
+                        integration_id=str(integration_id),
+                        webhook_id=None,
                         config_data={},
                         error=error_message
                     )


### PR DESCRIPTION
This PR introduces the following improvements:

- Support for setting a TTL in the configuration manager (both for webhook and action configs)
- Reduces requests made to the portal in webhook integrations by caching integration details (using the previous TTL feature)
- Extended retry time and larger initial wait time on failed requests to our Gundi API
- Better error handling and error messages in activity logs on webhook processing errors
- Extended test coverage for TTL feature, webhook configs and error handling