### PR TITLE
Allow overriding action and integration type display names

### DIFF
--- a/app/actions/core.py
+++ b/app/actions/core.py
@@ -37,6 +37,15 @@ class ExecutableActionMixin:
     pass
 
 
+def action_title(title: str):
+    """Set the display name used when registering the action in Gundi,
+    instead of the default derived from the handler function name."""
+    def decorator(func):
+        setattr(func, "action_title", title)
+        return func
+    return decorator
+
+
 class PushActionConfiguration(ActionConfiguration):
     pass
 

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1037,6 +1037,7 @@ def mock_pull_observations_action_handler():
     mock_pull_observations_action_handler = AsyncMock()
     mock_pull_observations_action_handler.return_value = {"observations_extracted": 10}
     mock_pull_observations_action_handler.crontab_schedule = CrontabSchedule.parse_obj_from_crontab("*/10 * * * * -5")
+    del mock_pull_observations_action_handler.action_title
     return mock_pull_observations_action_handler
 
 
@@ -1045,6 +1046,7 @@ def mock_pull_observations_by_date_action_handler():
     mock_pull_observations_by_date_action_handler = AsyncMock()
     mock_pull_observations_by_date_action_handler.return_value = {"observations_extracted": 10}
     del mock_pull_observations_by_date_action_handler.crontab_schedule
+    del mock_pull_observations_by_date_action_handler.action_title
     return mock_pull_observations_by_date_action_handler
 
 
@@ -1052,6 +1054,7 @@ def mock_pull_observations_by_date_action_handler():
 def mock_push_observations_handler():
     mock_push_observations_handler = AsyncMock()
     mock_push_observations_handler.return_value = {"observations_pushed": 1}
+    del mock_push_observations_handler.action_title
     return mock_push_observations_handler
 
 
@@ -1146,6 +1149,7 @@ def mock_auth_action_handlers():
         "username": "me@example.com",
         "password": "something-fancy",
     }
+    del mock_action_handler.action_title
     mock_action_handlers = {
         "auth": (mock_action_handler, MockAuthenticateActionConfiguration, None)
     }

--- a/app/register.py
+++ b/app/register.py
@@ -9,13 +9,14 @@ from app.services.action_scheduler import CrontabSchedule
 
 @click.command()
 @click.option('--slug', default=None, help='Slug ID for the integration type')
+@click.option('--name', default=None, help='Display name for the integration type (defaults to a name derived from the slug)')
 @click.option('--service-url', default=None, help='Service URL used to trigger actions or receive webhooks')
 @click.option(
     '--schedule',
     multiple=True,
     help='Schedules in the format "action_id:crontab schedule" (e.g., "pull_events:0 */4 * * *")'
 )
-def register_integration(slug, service_url, schedule):
+def register_integration(slug, name, service_url, schedule):
     schedules = {}
     for item in schedule:
         try:
@@ -29,6 +30,7 @@ def register_integration(slug, service_url, schedule):
         register_integration_in_gundi(
             gundi_client=_portal,
             type_slug=slug,
+            type_name=name,
             service_url=service_url,
             action_schedules=schedules
         )

--- a/app/services/self_registration.py
+++ b/app/services/self_registration.py
@@ -13,14 +13,14 @@ from app.actions import (
     ExecutableActionMixin,
     InternalActionConfiguration,
 )
-from app.settings import INTEGRATION_TYPE_SLUG, INTEGRATION_SERVICE_URL
+from app.settings import INTEGRATION_TYPE_SLUG, INTEGRATION_TYPE_NAME, INTEGRATION_SERVICE_URL
 from .core import ActionTypeEnum
 from app.webhooks.core import get_webhook_handler, GenericJsonTransformConfig
 
 logger = logging.getLogger(__name__)
 
 
-async def register_integration_in_gundi(gundi_client, type_slug=None, service_url=None, action_schedules=None):
+async def register_integration_in_gundi(gundi_client, type_slug=None, type_name=None, service_url=None, action_schedules=None):
     # Prepare the integration name and value
     integration_type_slug = type_slug or INTEGRATION_TYPE_SLUG
     if not integration_type_slug:
@@ -28,7 +28,7 @@ async def register_integration_in_gundi(gundi_client, type_slug=None, service_ur
             "Please define a slug id for this integration type, either passing it in the type_slug argument or setting it in the INTEGRATION_TYPE_SLUG setting."
         )
     integration_type_slug = integration_type_slug.strip().lower()
-    integration_type_name = integration_type_slug.replace("_", " ").title()
+    integration_type_name = type_name or INTEGRATION_TYPE_NAME or integration_type_slug.replace("_", " ").title()
     logger.info(f"Registering integration type '{integration_type_slug}'...")
     data = {
         "name": integration_type_name,
@@ -48,7 +48,7 @@ async def register_integration_in_gundi(gundi_client, type_slug=None, service_ur
         if issubclass(config_model, InternalActionConfiguration):
             logger.info(f"Skipping internal action '{action_id}'.")
             continue  # Internal actions are not registered in Gundi
-        action_name = action_id.replace("_", " ").title()
+        action_name = getattr(func, "action_title", None) or action_id.replace("_", " ").title()
         action_schema = json.loads(config_model.schema_json())
         action_ui_schema = config_model.ui_schema()
         if issubclass(config_model, AuthActionConfiguration):

--- a/app/services/tests/test_self_registration.py
+++ b/app/services/tests/test_self_registration.py
@@ -1,5 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
+from app.actions import action_title
 from app.main import app
 from app.services.self_registration import register_integration_in_gundi
 from app.services.action_scheduler import crontab_schedule, CrontabSchedule
@@ -614,6 +615,100 @@ async def test_register_integration_with_executable_action(
             },
         }
     )
+
+
+@pytest.mark.asyncio
+async def test_register_integration_with_type_name_arg(
+    mocker,
+    mock_gundi_client_v2,
+    mock_action_handlers,
+    mock_get_webhook_handler_for_fixed_json_payload,
+):
+    mocker.patch("app.services.self_registration.action_handlers", mock_action_handlers)
+    mocker.patch(
+        "app.services.self_registration.get_webhook_handler",
+        mock_get_webhook_handler_for_fixed_json_payload,
+    )
+    await register_integration_in_gundi(
+        gundi_client=mock_gundi_client_v2,
+        type_slug="savannahtracking",
+        type_name="Savannah Tracking",
+    )
+    assert mock_gundi_client_v2.register_integration_type.called
+    data = mock_gundi_client_v2.register_integration_type.call_args.args[0]
+    assert data["name"] == "Savannah Tracking"
+    assert data["value"] == "savannahtracking"
+    assert data["description"] == "Default type for integrations with Savannah Tracking"
+    pull_action = next(a for a in data["actions"] if a["value"] == "pull_observations")
+    assert pull_action["description"] == "Savannah Tracking Pull Observations action"
+    assert data["webhook"]["name"] == "Savannah Tracking Webhook"
+    assert data["webhook"]["description"] == "Webhook Integration with Savannah Tracking"
+
+
+@pytest.mark.asyncio
+async def test_register_integration_with_type_name_setting(
+    mocker,
+    mock_gundi_client_v2,
+    mock_action_handlers,
+    mock_get_webhook_handler_for_fixed_json_payload,
+):
+    mocker.patch("app.services.self_registration.INTEGRATION_TYPE_SLUG", "savannahtracking")
+    mocker.patch("app.services.self_registration.INTEGRATION_TYPE_NAME", "Savannah Tracking")
+    mocker.patch("app.services.self_registration.action_handlers", mock_action_handlers)
+    mocker.patch(
+        "app.services.self_registration.get_webhook_handler",
+        mock_get_webhook_handler_for_fixed_json_payload,
+    )
+    await register_integration_in_gundi(gundi_client=mock_gundi_client_v2)
+    assert mock_gundi_client_v2.register_integration_type.called
+    data = mock_gundi_client_v2.register_integration_type.call_args.args[0]
+    assert data["name"] == "Savannah Tracking"
+    assert data["value"] == "savannahtracking"
+
+
+@pytest.mark.asyncio
+async def test_register_integration_with_action_title(
+    mocker,
+    mock_gundi_client_v2,
+    mock_action_handlers,
+    mock_get_webhook_handler_for_fixed_json_payload,
+):
+    mocker.patch("app.services.self_registration.INTEGRATION_TYPE_SLUG", "x_tracker")
+    mock_action_handlers["pull_observations"][0].action_title = "Fetch Collar Positions"
+    mocker.patch("app.services.self_registration.action_handlers", mock_action_handlers)
+    mocker.patch(
+        "app.services.self_registration.get_webhook_handler",
+        mock_get_webhook_handler_for_fixed_json_payload,
+    )
+    await register_integration_in_gundi(gundi_client=mock_gundi_client_v2)
+    assert mock_gundi_client_v2.register_integration_type.called
+    data = mock_gundi_client_v2.register_integration_type.call_args.args[0]
+    pull_action = next(a for a in data["actions"] if a["value"] == "pull_observations")
+    assert pull_action["name"] == "Fetch Collar Positions"
+    assert pull_action["description"] == "X Tracker Fetch Collar Positions action"
+    # Actions without a custom title keep the name derived from the action id
+    push_action = next(a for a in data["actions"] if a["value"] == "push_observations")
+    assert push_action["name"] == "Push Observations"
+
+
+def test_action_title_decorator():
+
+    @action_title("Fetch Collar Positions")
+    async def action_pull_observations(integration, action_config):
+        return {"observations_extracted": 10}
+
+    assert action_pull_observations.action_title == "Fetch Collar Positions"
+
+
+def test_action_title_decorator_stacks_with_crontab_schedule():
+
+    @action_title("Fetch Collar Positions")
+    @crontab_schedule("*/10 * * * *")
+    async def action_pull_observations(integration, action_config):
+        return {"observations_extracted": 10}
+
+    assert action_pull_observations.action_title == "Fetch Collar Positions"
+    assert action_pull_observations.crontab_schedule == CrontabSchedule.parse_obj_from_crontab("*/10 * * * *")
 
 
 @pytest.mark.asyncio

--- a/app/settings/base.py
+++ b/app/settings/base.py
@@ -64,6 +64,7 @@ REDIS_CONFIGS_DB = env.int("REDIS_CONFIGS_DB", 1)  # ToDo: define a convention f
 
 REGISTER_ON_START = env.bool("REGISTER_ON_START", False)
 INTEGRATION_TYPE_SLUG = env.str("INTEGRATION_TYPE_SLUG", None)  # Define a string id here e.g. "my_tracker"
+INTEGRATION_TYPE_NAME = env.str("INTEGRATION_TYPE_NAME", None)  # Display name e.g. "My Tracker"; defaults to a name derived from the slug
 INTEGRATION_SERVICE_URL = env.str("INTEGRATION_SERVICE_URL", None)  # Define a string id here e.g. "my_tracker"
 PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND = env.bool("PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND", False)
 PROCESS_WEBHOOKS_IN_BACKGROUND = env.bool("PROCESS_WEBHOOKS_IN_BACKGROUND", True)


### PR DESCRIPTION
Registration currently derives display names mechanically: an action's `name` from the handler function name (`action_pull_observations` → "Pull Observations") and the integration type's `name` from the slug — which produces wrong names for multi-word brands (`savannahtracking` → "Savannahtracking" instead of "Savannah Tracking"). There is no way to set either name directly.

This adds two optional, backward-compatible overrides:

## `@action_title` decorator

```python
@action_title("Fetch Collar Positions")
@crontab_schedule("*/10 * * * *")
async def action_pull_observations(integration, action_config: PullObservationsConfig):
    ...
```

Sets the action's registered display name instead of deriving it from the handler function name. Mirrors the `@crontab_schedule` attribute pattern (no wrapper — it tags the function, so it stacks with other decorators in either order). The custom name also flows into the generated action description.

## Integration type name: `--name` / `INTEGRATION_TYPE_NAME`

```bash
python -m app.register --slug savannahtracking --name "Savannah Tracking"
```

Same three-layer precedence as slug/service_url: CLI arg → `INTEGRATION_TYPE_NAME` env setting → derived from the slug. The name flows everywhere the derived name was used: type name/description, action descriptions, and the webhook name/description.

## Compatibility

Both overrides are optional; the derived names remain the fallback, so existing integrations are unaffected.

## Testing

- 5 new tests: `--name` arg, `INTEGRATION_TYPE_NAME` setting, custom action title in the registration payload (with undecorated actions keeping derived names), and the decorator alone and stacked with `@crontab_schedule`.
- Mock handler fixtures get `del mock.action_title` so `AsyncMock` attribute auto-creation doesn't fabricate titles — same idiom the conftest already uses for `crontab_schedule`.
- Full suite: 77 passed on top of current main (d416ff7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
