### PR TITLE
Template hardening: py3.10 fixes, SSRF bypass, log redaction, config-cache sentinel, CI fix

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -14,7 +14,9 @@ jobs:
       - name: Install pip
         run: python -m ensurepip --upgrade
       - name: Install pip tools
-        run: pip install pip-tools
+        # typing_extensions listed explicitly: pip-tools 7.6.0 imports it on
+        # Python 3.10 without declaring it as a dependency
+        run: pip install pip-tools typing_extensions
       - name: Install compile dependencies
         run: pip-compile --output-file=requirements.txt requirements-base.in requirements-dev.in requirements.in
       - name: Install dependencies

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ import os
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request, status, BackgroundTasks
 from fastapi.encoders import jsonable_encoder
-from fastapi.exceptions import RequestValidationError, HTTPException
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from app.routers import actions, webhooks, config_events
 import app.settings as settings
@@ -117,15 +117,16 @@ async def push_data(
     logger.debug(f"Attributes: {attributes}")
     destination_id = attributes.get("destination_id")
     if not destination_id:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Missing required attribute: 'destination_id'"
-        )
-    return await execute_action(
+        # Ack malformed messages (2xx) — raising here would make PubSub
+        # redeliver a message that can never succeed.
+        logger.error(f"PubSub message missing required attribute 'destination_id': {attributes}")
+        return {}
+    await execute_action(
         integration_id=destination_id,
         data=json_payload,
         metadata=attributes
     )
+    return {}
 
 app.include_router(
     actions.router, prefix="/v1/actions", tags=["actions"], responses={}

--- a/app/main.py
+++ b/app/main.py
@@ -117,16 +117,21 @@ async def push_data(
     logger.debug(f"Attributes: {attributes}")
     destination_id = attributes.get("destination_id")
     if not destination_id:
-        # Ack malformed messages (2xx) — raising here would make PubSub
-        # redeliver a message that can never succeed.
-        logger.error(f"PubSub message missing required attribute 'destination_id': {attributes}")
+        # Ack malformed messages (2xx) — they can never succeed, so a non-2xx
+        # would only make PubSub redeliver them forever. Log attribute keys
+        # only; the values may carry sensitive data.
+        logger.error(
+            f"PubSub message missing required attribute 'destination_id'. "
+            f"Attribute keys: {sorted(attributes.keys())}"
+        )
         return {}
-    await execute_action(
+    # Push data rides in the message itself, so execution errors must propagate
+    # (non-2xx) for PubSub to redeliver — acking a failed run would drop data.
+    return await execute_action(
         integration_id=destination_id,
         data=json_payload,
         metadata=attributes
     )
-    return {}
 
 app.include_router(
     actions.router, prefix="/v1/actions", tags=["actions"], responses={}

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -5,7 +5,6 @@ import traceback
 from enum import Enum
 from typing import Optional
 
-import httpx
 import pydantic
 import stamina
 from gundi_client_v2 import GundiClient
@@ -20,7 +19,6 @@ from gundi_core.events import IntegrationActionFailed, ActionExecutionFailed, Lo
 from app.actions.core import PullActionConfiguration
 from .config_manager import IntegrationConfigurationManager
 from .state import IntegrationStateManager
-from .utils import find_config_for_action
 from .activity_logger import publish_event, log_action_activity
 
 _portal = GundiClient()
@@ -263,7 +261,7 @@ async def execute_action(
         }
         if parsed_data:
             handler_kwargs["data"] = parsed_data
-        if metadata:
+        if metadata is not None:
             handler_kwargs["metadata"] = metadata
         result = await asyncio.wait_for(
             handler(**handler_kwargs),

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -45,7 +45,7 @@ class IntegrationConfigurationManager:
                 await self.db_client.set(webhook_key, webhook_configuration.json(), ttl)
             return integration_details
 
-    async def get_action_configuration(self, integration_id: str, action_id: str, ttl=None) -> IntegrationActionConfiguration:
+    async def get_action_configuration(self, integration_id: str, action_id: str, ttl=None) -> Optional[IntegrationActionConfiguration]:
         key = self._get_action_config_key(integration_id, action_id)
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -1,4 +1,6 @@
 import json
+from typing import Optional
+
 import stamina
 import httpx
 import redis.asyncio as redis
@@ -54,7 +56,7 @@ class IntegrationConfigurationManager:
         integration_details = await self._reload_integration_from_gundi(integration_id, ttl)
         return integration_details.get_action_config(action_id)
 
-    async def get_webhook_configuration(self, integration_id: str, ttl=None) -> WebhookConfiguration:
+    async def get_webhook_configuration(self, integration_id: str, ttl=None) -> Optional[WebhookConfiguration]:
         key = self._get_webhook_config_key(integration_id)
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -9,6 +9,11 @@ from gundi_client_v2 import GundiClient
 from app import settings
 
 
+# Cached marker meaning "this integration has no webhook configuration", so a
+# cold cache doesn't trigger a Gundi API reload on every webhook-config lookup.
+_NO_WEBHOOK_CONFIG_SENTINEL = "null"
+
+
 class IntegrationConfigurationManager:
     # ToDo: Add support for webhook configs
 
@@ -39,10 +44,13 @@ class IntegrationConfigurationManager:
             for config in integration_details.configurations:
                 config_key = self._get_action_config_key(integration_id, config.action.value)
                 await self.db_client.set(config_key, config.json(), ttl)
-            # Save webhook configuration if present
+            # Save the webhook configuration — or a sentinel marking its absence, so
+            # integrations without one don't reload from the Gundi API on every lookup
+            webhook_key = self._get_webhook_config_key(integration_id)
             if webhook_configuration := integration_details.webhook_configuration:
-                webhook_key = self._get_webhook_config_key(integration_id)
                 await self.db_client.set(webhook_key, webhook_configuration.json(), ttl)
+            else:
+                await self.db_client.set(webhook_key, _NO_WEBHOOK_CONFIG_SENTINEL, ttl)
             return integration_details
 
     async def get_action_configuration(self, integration_id: str, action_id: str, ttl=None) -> Optional[IntegrationActionConfiguration]:
@@ -62,6 +70,8 @@ class IntegrationConfigurationManager:
             with attempt:
                 data = await self.db_client.get(key)
         if data:
+            if data in (_NO_WEBHOOK_CONFIG_SENTINEL, _NO_WEBHOOK_CONFIG_SENTINEL.encode()):
+                return None  # cached absence — this integration has no webhook config
             return WebhookConfiguration.parse_raw(data)
         # If not found in the redis db, try reloading data from Gundi API
         integration_details = await self._reload_integration_from_gundi(integration_id, ttl)

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -590,3 +590,24 @@ async def test_execute_action_with_handler_error(
     assert event.payload.server_response_status == expected_error.response.status_code
     assert event.payload.server_response_body == str(expected_error.response.text)
 
+
+
+@pytest.mark.asyncio
+async def test_push_data_acks_message_without_destination_id(
+        mocker, pubsub_message_request_headers, run_push_action_pubsub_payload
+):
+    mock_execute_action = mocker.patch("app.main.execute_action")
+    payload = json.loads(json.dumps(run_push_action_pubsub_payload))
+    payload["message"]["attributes"].pop("destination_id", None)
+
+    response = api_client.post(
+        "/push-data",
+        headers=pubsub_message_request_headers,
+        json=payload,
+    )
+
+    # Malformed messages are acked (2xx) so PubSub doesn't redeliver them forever,
+    # and the action runner is never invoked.
+    assert response.status_code == 200
+    assert response.json() == {}
+    assert not mock_execute_action.called

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -321,3 +321,40 @@ async def test_get_integration_details_with_ttl(
     for call in set_calls:
         assert call[0][2] == ttl  # TTL is the third argument
 
+
+
+@pytest.mark.asyncio
+async def test_get_webhook_configuration_caches_absence_sentinel(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+
+    webhook_config = await config_manager.get_webhook_configuration(integration_id)
+
+    assert webhook_config is None
+    # The absence is cached, so the next cold lookup won't reload from Gundi.
+    mock_redis_empty.Redis.return_value.set.assert_any_call(
+        f"integrationconfig.{integration_id}.webhook", "null", None
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_webhook_configuration_reads_cached_absence_sentinel(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    import asyncio as _asyncio
+    fut = _asyncio.get_event_loop().create_future()
+    fut.set_result(b"null")
+    mock_redis_empty.Redis.return_value.get.return_value = fut
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+
+    webhook_config = await config_manager.get_webhook_configuration(str(integration_v2.id))
+
+    assert webhook_config is None
+    # Sentinel hit — no reload from the Gundi API.
+    assert not mock_gundi_client_v2_class.return_value.get_integration_details.called

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -346,7 +346,7 @@ async def test_get_webhook_configuration_reads_cached_absence_sentinel(
         mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
 ):
     import asyncio as _asyncio
-    fut = _asyncio.get_event_loop().create_future()
+    fut = _asyncio.get_running_loop().create_future()
     fut.set_result(b"null")
     mock_redis_empty.Redis.return_value.get.return_value = fut
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)

--- a/app/services/tests/test_diagnostic_url_validation.py
+++ b/app/services/tests/test_diagnostic_url_validation.py
@@ -1,0 +1,44 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.webhooks import _validate_diagnostic_url
+
+
+def _addrinfo(ip):
+    # Matches the (family, type, proto, canonname, sockaddr) shape returned by getaddrinfo.
+    return [(None, None, None, None, (ip, 443))]
+
+
+def _mock_resolution(mocker, ip):
+    mock_loop = mocker.MagicMock()
+    mock_loop.getaddrinfo = AsyncMock(return_value=_addrinfo(ip))
+    mocker.patch("app.services.webhooks.asyncio.get_running_loop", return_value=mock_loop)
+
+
+@pytest.mark.asyncio
+async def test_ipv4_mapped_ipv6_loopback_is_blocked(mocker):
+    # ::ffff:127.0.0.1 parses as IPv6, so the plain IPv4 blocklist alone misses it.
+    _mock_resolution(mocker, "::ffff:127.0.0.1")
+    with pytest.raises(ValueError, match="private or reserved"):
+        await _validate_diagnostic_url("https://example.com/hook")
+
+
+@pytest.mark.asyncio
+async def test_ipv4_mapped_ipv6_private_is_blocked(mocker):
+    _mock_resolution(mocker, "::ffff:169.254.169.254")
+    with pytest.raises(ValueError, match="private or reserved"):
+        await _validate_diagnostic_url("https://example.com/hook")
+
+
+@pytest.mark.asyncio
+async def test_ipv6_multicast_is_blocked(mocker):
+    _mock_resolution(mocker, "ff02::1")
+    with pytest.raises(ValueError, match="private or reserved"):
+        await _validate_diagnostic_url("https://example.com/hook")
+
+
+@pytest.mark.asyncio
+async def test_public_address_is_allowed(mocker):
+    _mock_resolution(mocker, "93.184.216.34")
+    await _validate_diagnostic_url("https://example.com/hook")

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -3,7 +3,6 @@ import datetime
 import importlib
 import ipaddress
 import logging
-import traceback
 from urllib.parse import urlparse
 import httpx
 import stamina

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -46,6 +46,8 @@ _BLOCKED_NETWORKS = [
     ipaddress.ip_network("100.64.0.0/10"),    # carrier-grade NAT
     ipaddress.ip_network("224.0.0.0/4"),      # multicast
     ipaddress.ip_network("240.0.0.0/4"),      # reserved
+    ipaddress.ip_network("::/128"),           # IPv6 unspecified
+    ipaddress.ip_network("ff00::/8"),         # IPv6 multicast
 ]
 
 
@@ -78,6 +80,10 @@ async def _validate_diagnostic_url(url: str) -> None:
         raise ValueError(f"Cannot resolve diagnostic URL hostname '{hostname}': {e}")
     for _, _, _, _, sockaddr in addr_infos:
         ip = ipaddress.ip_address(sockaddr[0])
+        # An IPv4-mapped IPv6 address (::ffff:a.b.c.d) parses as IPv6 and would
+        # sail past the IPv4 blocklist entries; check the embedded IPv4 instead.
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
+            ip = ip.ipv4_mapped
         if any(ip in net for net in _BLOCKED_NETWORKS):
             raise ValueError(
                 f"Diagnostic URL resolves to a private or reserved address ({ip}), "

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -86,6 +86,16 @@ async def _validate_diagnostic_url(url: str) -> None:
             )
 
 
+def _redact_url(url: str) -> str:
+    """Host and path only — diagnostic URLs can carry credentials or tokens
+    in the userinfo or query string, which must not reach the logs."""
+    try:
+        parsed = urlparse(url)
+        return f"{parsed.hostname}{parsed.path}"
+    except Exception:
+        return "<unparseable url>"
+
+
 async def forward_payload_to_diagnostic_url(
     destination_url: str,
     integration_id: str,
@@ -104,12 +114,12 @@ async def forward_payload_to_diagnostic_url(
         response = await _get_diagnostic_client().post(destination_url, json=body)
         response.raise_for_status()
         logger.debug(
-            f"Diagnostic payload forwarded to '{destination_url}' "
+            f"Diagnostic payload forwarded to '{_redact_url(destination_url)}' "
             f"for integration '{integration_id}'. Status: {response.status_code}"
         )
     except Exception as e:
         logger.warning(
-            f"Diagnostic forwarding to '{destination_url}' failed for integration "
+            f"Diagnostic forwarding to '{_redact_url(destination_url)}' failed for integration "
             f"'{integration_id}': {type(e).__name__}: {e}"
         )
 

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -95,7 +95,7 @@ async def forward_payload_to_diagnostic_url(
         await _validate_diagnostic_url(destination_url)
         metadata = {
             "integration_id": integration_id,
-            "received_at": datetime.datetime.now(datetime.UTC).isoformat() + "Z",
+            "received_at": datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
         }
         if isinstance(json_content, dict):
             body = {**json_content, "__gundi_diagnostic_metadata": metadata}
@@ -149,7 +149,12 @@ async def process_webhook(request: Request):
         # Try to relate the request to an integration
         integration = await get_integration(request=request)
         if not integration:
-            logger.warning(f"No integration found for webhook request: headers: {request.headers}, query_params: {request.query_params}")
+            logger.warning(
+                "No integration found for webhook request: "
+                f"consumer_username: {request.headers.get('x-consumer-username')}, "
+                f"integration_id header: {request.headers.get('x-gundi-integration-id')}, "
+                f"integration_id param: {request.query_params.get('integration_id')}"
+            )
             return {}
         # Look for the handler function in webhooks/handlers.py
         webhook_handler, payload_model, config_model = get_webhook_handler()

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -96,7 +96,10 @@ def _redact_url(url: str) -> str:
     in the userinfo or query string, which must not reach the logs."""
     try:
         parsed = urlparse(url)
-        return f"{parsed.hostname}{parsed.path}"
+        host = parsed.hostname or "<no-host>"
+        if parsed.port:
+            host = f"{host}:{parsed.port}"
+        return f"{host}{parsed.path}"
     except Exception:
         return "<unparseable url>"
 

--- a/app/webhooks/core.py
+++ b/app/webhooks/core.py
@@ -55,8 +55,7 @@ class GenericJsonTransformConfig(JQTransformConfig, DynamicSchemaConfig):
     output_type: Optional[str] = FieldWithUIOptions(
         None,
         description=(
-            "Default output type for all transformed records: 'obv' (observations) or 'ev' (events). "
-            "Individual records can override this with a '__gundi_output_type' field."
+            "Output type for all transformed records: 'obv' (observations) or 'ev' (events)."
         ),
         ui_options=UIOptions(
             widget="text",  # ToDo: Use a select or a better widget to render the output type

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -66,6 +66,10 @@ services:
       retries: 5
 
   web-ui:
+    # The web-ui sources are not shipped in this repo (nor in the upstream
+    # template), so this service is opt-in: `docker compose --profile web-ui up`.
+    # Without the profile, `docker compose up` skips it instead of failing the build.
+    profiles: ["web-ui"]
     build:
       context: ./web-ui
       dockerfile: Dockerfile


### PR DESCRIPTION
Batch of template fixes surfaced by automated review of a downstream fork sync (PADAS/gundi-integration-movebank#10) — all applied and green downstream first, ported here so every integration inherits them.

### Runtime crashes / correctness
- **`datetime.UTC` crash on py3.10** (`app/services/webhooks.py`): the alias is 3.11+, but the Dockerfile runs `python:3.10-slim` — any diagnostic-webhook forward raised `AttributeError`. Also emits a valid RFC3339 `Z` timestamp (was `+00:00Z`).
- **`/push-data` PubSub redelivery loop** (`app/main.py`): raising 400 on a missing `destination_id` makes PubSub redeliver an unfixable message forever; now logs and acks, mirroring `/`.
- **`metadata` dropped when empty** (`app/services/action_runner.py`): `if metadata:` omitted an empty dict, raising `TypeError` in push handlers that require the parameter; now `is not None`.

### Security
- **SSRF blocklist bypass via IPv4-mapped IPv6** (`app/services/webhooks.py`): `::ffff:127.0.0.1` parses as IPv6 and passed every IPv4 blocklist entry; the validator now unwraps `ip.ipv4_mapped` first, and blocks `::/128` + `ff00::/8`. Regression tests added.
- **Credential leakage in logs** (`app/services/webhooks.py`): the integration-lookup warning logged full request headers/query params; diagnostic-forwarding logs printed full destination URLs. Both now log only identifying values / host+path.

### Performance
- **Webhook-config cache sentinel** (`app/services/config_manager.py`): integrations without a webhook configuration reloaded from the Gundi API on every cold lookup (no key was ever written); the reload now caches a `null` sentinel. Tests added.

### Hygiene
- `Optional[...]` annotations on `get_action_configuration` / `get_webhook_configuration` (both return `None` for unconfigured integrations); unused imports removed (`traceback`, `httpx`, `find_config_for_action`); stale `__gundi_output_type` claim removed from the `output_type` description (nothing reads that field); `local/docker-compose.yml` `web-ui` service moved behind a profile (its sources aren't shipped, so default `docker compose up` failed at build).

### CI
- **`pip-tools` 7.6.0 breaks the test workflow on py3.10**: it imports `typing_extensions` without declaring the dependency, so the fresh `pip install pip-tools` in `_tests.yml` crashes at `pip-compile`. Now installed explicitly.

Branch is merged up to current `main` (includes #80). Suite: 85 passed (77 base + 2 from #80 + 6 new regression tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
