### PR TITLE
Keep discover_actions from treating imported helpers as actions

### DIFF
--- a/app/actions/core.py
+++ b/app/actions/core.py
@@ -1,9 +1,12 @@
 import importlib
 import inspect
+import logging
 from typing import Optional
 
 from pydantic import BaseModel, Field
 from app.services.utils import UISchemaModelMixin
+
+logger = logging.getLogger(__name__)
 
 
 class ActionConfiguration(UISchemaModelMixin, BaseModel):
@@ -67,8 +70,16 @@ def discover_actions(module_name, prefix):
     # Iterate through the members and filter functions by prefix
     for name, func in all_members:
         if name.startswith(prefix) and inspect.isfunction(func):
+            if func is action_title:
+                continue  # The decorator itself, often imported alongside handlers
             signature = inspect.signature(func)
             key = name[len(prefix):]  # Remove prefix
+            if "action_config" not in signature.parameters:
+                logger.warning(
+                    f"Ignoring '{name}' in '{module_name}': functions prefixed with "
+                    f"'{prefix}' must accept an 'action_config' argument to be registered as actions."
+                )
+                continue
             if (config_annotation := signature.parameters.get("action_config").annotation) != inspect._empty:
                 config_model = config_annotation
             else:

--- a/app/services/tests/test_self_registration.py
+++ b/app/services/tests/test_self_registration.py
@@ -1,6 +1,9 @@
+import sys
+import types
+
 import pytest
 from fastapi.testclient import TestClient
-from app.actions import action_title
+from app.actions import action_title, discover_actions, PullActionConfiguration
 from app.main import app
 from app.services.self_registration import register_integration_in_gundi
 from app.services.action_scheduler import crontab_schedule, CrontabSchedule
@@ -709,6 +712,51 @@ def test_action_title_decorator_stacks_with_crontab_schedule():
 
     assert action_pull_observations.action_title == "Fetch Collar Positions"
     assert action_pull_observations.crontab_schedule == CrontabSchedule.parse_obj_from_crontab("*/10 * * * *")
+
+
+def _discover_actions_in_fake_module(module):
+    module_name = "fake_handlers_module"
+    sys.modules[module_name] = module
+    try:
+        return discover_actions(module_name=module_name, prefix="action_")
+    finally:
+        del sys.modules[module_name]
+
+
+def test_discover_actions_ignores_imported_action_title_decorator():
+    # Simulates handlers.py doing `from app.actions import action_title`
+    module = types.ModuleType("fake_handlers_module")
+    module.action_title = action_title
+
+    @action_title("Fetch Collar Positions")
+    async def action_pull_observations(integration, action_config: PullActionConfiguration):
+        return {"observations_extracted": 10}
+
+    module.action_pull_observations = action_pull_observations
+
+    handlers = _discover_actions_in_fake_module(module)
+
+    assert "title" not in handlers
+    assert list(handlers.keys()) == ["pull_observations"]
+    assert handlers["pull_observations"][0] is action_pull_observations
+
+
+def test_discover_actions_ignores_functions_without_action_config():
+    module = types.ModuleType("fake_handlers_module")
+
+    def action_helper(value):
+        return value
+
+    async def action_pull_observations(integration, action_config: PullActionConfiguration):
+        return {"observations_extracted": 10}
+
+    module.action_helper = action_helper
+    module.action_pull_observations = action_pull_observations
+
+    handlers = _discover_actions_in_fake_module(module)
+
+    assert "helper" not in handlers
+    assert list(handlers.keys()) == ["pull_observations"]
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_self_registration.py
+++ b/app/services/tests/test_self_registration.py
@@ -716,11 +716,15 @@ def test_action_title_decorator_stacks_with_crontab_schedule():
 
 def _discover_actions_in_fake_module(module):
     module_name = "fake_handlers_module"
+    previous = sys.modules.get(module_name)
     sys.modules[module_name] = module
     try:
         return discover_actions(module_name=module_name, prefix="action_")
     finally:
-        del sys.modules[module_name]
+        if previous is not None:
+            sys.modules[module_name] = previous
+        else:
+            del sys.modules[module_name]
 
 
 def test_discover_actions_ignores_imported_action_title_decorator():


### PR DESCRIPTION
## Summary

Importing the `@action_title` decorator (added in #77) into an integration's `handlers.py` crashed action discovery at import time with `AttributeError: 'NoneType' object has no attribute 'annotation'`.

`discover_actions` treats any function in the handlers module namespace whose name starts with the `action_` prefix as an action handler, so the imported `action_title` function itself was picked up as an action named "title" and discovery failed when inspecting its (nonexistent) `action_config` parameter.

## Changes

- Skip the `action_title` decorator itself during discovery (identity check), since importing it alongside handlers is the intended usage.
- More generally, skip any `action_`-prefixed function that lacks an `action_config` parameter, logging a warning — every valid handler must accept one (the previous code already dereferenced it unconditionally). This also protects against other imported `action_`-named helpers and replaces the cryptic `AttributeError` with an actionable message for genuinely mis-declared handlers.

## Test plan

- New test reproducing the exact scenario: a handlers module that imports `action_title` and defines a decorated handler — discovery previously crashed, now registers only the handler.
- New test for a generic `action_`-named helper without `action_config` being skipped.
- Full suite passes (79 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)